### PR TITLE
[DL-19494] Redirect to error page if user has affinityGroup = Agent

### DIFF
--- a/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/JourneyController.scala
+++ b/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/JourneyController.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.claimvatenrolmentfrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{credentialRole, internalId}
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual, Organisation}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole, internalId}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisedFunctions, User}
 import uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.{routes => errorRoutes}
@@ -31,27 +32,30 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class JourneyController @Inject()(journeyService: JourneyService,
-                                  mcc: MessagesControllerComponents,
-                                  val authConnector: AuthConnector
-                                 )(implicit ec: ExecutionContext) extends FrontendController(mcc) with AuthorisedFunctions with LoggingUtil {
+class JourneyController @Inject() (journeyService: JourneyService, mcc: MessagesControllerComponents, val authConnector: AuthConnector)(implicit
+    ec: ExecutionContext)
+    extends FrontendController(mcc)
+    with AuthorisedFunctions
+    with LoggingUtil {
 
-  def createJourney(vatNumber: String, continueUrl: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      authorised().retrieve(internalId and credentialRole) {
-        case Some(authId) ~ Some(User) =>
-          infoLog(s"[JourneyController][createJourney] Creating journey")
-          journeyService.createJourney(JourneyConfig(continueUrl), vatNumber, authId).map {
-            journeyId => Redirect(routes.CaptureVatRegistrationDateController.show(journeyId).url)
-          }
-        case Some(_) ~ _ =>
-          warnLog("[JourneyController][createJourney] Invalid account type controller")
-          Future.successful(Redirect(errorRoutes.InvalidAccountTypeController.show().url))
-        case None ~ _ =>
-          val message = "Internal ID could not be retrieved from Auth"
-          errorLog(s"[JourneyController][createJourney] $message")
-          throw new InternalServerException(message)
-      }
+  def createJourney(vatNumber: String, continueUrl: String): Action[AnyContent] = Action.async { implicit request =>
+    authorised().retrieve(internalId and credentialRole and affinityGroup) {
+      case Some(authId) ~ Some(User) ~ Some(userType) if userType == Individual || userType == Organisation =>
+        infoLog(s"[JourneyController][createJourney] Creating journey")
+        journeyService.createJourney(JourneyConfig(continueUrl), vatNumber, authId).map { journeyId =>
+          Redirect(routes.CaptureVatRegistrationDateController.show(journeyId).url)
+        }
+      case Some(_) ~ Some(User) ~ Some(userType) if userType == Agent =>
+        warnLog("[JourneyController][createJourney] Invalid affinity group: Agent is trying to access the journey")
+        Future.successful(Redirect(errorRoutes.InvalidAccountTypeController.showUserIsAnAgentError().url))
+      case Some(_) ~ _ ~ _ =>
+        warnLog("[JourneyController][createJourney] Invalid account type controller")
+        Future.successful(Redirect(errorRoutes.InvalidAccountTypeController.showInvalidAccountTypeError().url))
+      case None ~ _ ~ _ =>
+        val message = "Internal ID could not be retrieved from Auth"
+        errorLog(s"[JourneyController][createJourney] $message")
+        throw new InternalServerException(message)
+    }
 
   }
 

--- a/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/InvalidAccountTypeController.scala
+++ b/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/InvalidAccountTypeController.scala
@@ -18,21 +18,24 @@ package uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.claimvatenrolmentfrontend.config.AppConfig
-import uk.gov.hmrc.claimvatenrolmentfrontend.controllers.{routes => appRoutes}
-import uk.gov.hmrc.claimvatenrolmentfrontend.views.html.errorPages.invalid_account_type
+import uk.gov.hmrc.claimvatenrolmentfrontend.views.html.errorPages.{invalid_account_type, user_is_an_agent_error_page}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
-class InvalidAccountTypeController @Inject()(mcc: MessagesControllerComponents,
-                                             view: invalid_account_type
-                                            )(implicit appConfig: AppConfig) extends FrontendController(mcc) {
+class InvalidAccountTypeController @Inject() (mcc: MessagesControllerComponents,
+                                              invalidAccountTypeView: invalid_account_type,
+                                              userIsAnAgentView: user_is_an_agent_error_page)(implicit appConfig: AppConfig)
+    extends FrontendController(mcc) {
 
-  val show: Action[AnyContent] = Action.async {
-    implicit request =>
-      Future.successful(Ok(view(appRoutes.SignInOutController.signOut)))
+  val showInvalidAccountTypeError: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(invalidAccountTypeView()))
+  }
+
+  val showUserIsAnAgentError: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(userIsAnAgentView()))
   }
 
 }

--- a/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/UnmatchedUserErrorController.scala
+++ b/app/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/UnmatchedUserErrorController.scala
@@ -29,7 +29,7 @@ class UnmatchedUserErrorController @Inject()(mcc: MessagesControllerComponents,
                                              view: unmatched_user_error_page
                                             )(implicit appConfig: AppConfig) extends FrontendController(mcc) {
 
-  def show: Action[AnyContent] = Action.async {
+  def show(): Action[AnyContent] = Action.async {
     implicit request =>
       Future.successful(Ok(view()))
   }

--- a/app/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/user_is_an_agent_error_page.scala.html
+++ b/app/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/user_is_an_agent_error_page.scala.html
@@ -26,11 +26,11 @@
 
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@layout(Some(titleNoForm(messages("invalid_account_type.title")))) {
+@layout(Some(titleNoForm(messages("user_is_an_agent.title")))) {
 
-    @h1(messages("invalid_account_type.heading"))
+    @h1(messages("user_is_an_agent.title"))
 
-    @p { @messages("invalid_account_type.line_1") }
+    @p { @messages("user_is_an_agent.p1") }
 
     @govukButton(Button(
         href = Some(routes.SignInOutController.signOut.url),
@@ -40,4 +40,5 @@
     ))
 
     <br/>
+
 }

--- a/app/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/user_is_an_agent_error_page.scala.html
+++ b/app/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/user_is_an_agent_error_page.scala.html
@@ -32,13 +32,4 @@
 
     @p { @messages("user_is_an_agent.p1") }
 
-    @govukButton(Button(
-        href = Some(routes.SignInOutController.signOut.url),
-        attributes = Map("id" -> "Sign out"),
-        classes = "govuk-!-margin-right-1",
-        content = Text(messages("app.common.signOut"))
-    ))
-
-    <br/>
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,6 @@ lazy val microservice = Project(appName, file("."))
     // ***************
   )
   .settings(scoverageSettings)
-  .settings(resolvers += Resolver.jcenterRepo)
   .disablePlugins(JUnitXmlReportPlugin)
 
 Test / Keys.fork := true

--- a/conf/error.routes
+++ b/conf/error.routes
@@ -1,5 +1,8 @@
 # Invalid Account Type Error
-GET         /not-authorised                             uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.InvalidAccountTypeController.show()
+GET         /not-authorised                             uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.InvalidAccountTypeController.showInvalidAccountTypeError()
+
+# Invalid User Is An Agent Error
+GET         /agent-not-authorised                       uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.InvalidAccountTypeController.showUserIsAnAgentError()
 
 # Unmatched User Error
 GET         /not-enrolled                               uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.UnmatchedUserErrorController.show()

--- a/conf/messages
+++ b/conf/messages
@@ -134,6 +134,10 @@ unmatched_user.heading                                      = You cannot use thi
 unmatched_user.line_1                                       = Go to your business tax account to
 unmatched_user.link                                         = manage who can access your taxes, duties and schemes
 
+# User Is An Agent Error Page
+user_is_an_agent.title                                      = Agents are not authorised to claim enrolments
+user_is_an_agent.p1                                         = This can only be done by registered users and their nominated assistants.
+
 # Enrolment Already Allocated Error Page
 enrolment_already_allocated.title                           = This business’s VAT has already been added to another business tax account
 enrolment_already_allocated.heading                         = This business’s VAT has already been added to another business tax account

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -133,6 +133,12 @@ unmatched_user.heading                                      = Allwch chi ddim de
 unmatched_user.line_1                                       = Ewch i’ch cyfrif treth busnes i
 unmatched_user.link                                         = reoli pwy all gael mynediad at eich trethi, eich tollau a’ch cynlluniau
 
+# User Is And Agent Error Page
+user_is_an_agent.title                                      = PLACEHOLDER
+user_is_an_agent.heading                                    = PLACEHOLDER
+user_is_an_agent.line_1                                     = PLACEHOLDER
+user_is_an_agent.link                                       = PLACEHOLDER
+
 # Enrolment Already Allocated Error Page
 enrolment_already_allocated.title                           = Mae TAW y busnes hwn eisoes wedi cael ei hychwanegu at gyfrif treth busnes arall
 enrolment_already_allocated.heading                         = Mae TAW y busnes hwn eisoes wedi cael ei hychwanegu at gyfrif treth busnes arall

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -134,10 +134,8 @@ unmatched_user.line_1                                       = Ewch i’ch cyfrif
 unmatched_user.link                                         = reoli pwy all gael mynediad at eich trethi, eich tollau a’ch cynlluniau
 
 # User Is And Agent Error Page
-user_is_an_agent.title                                      = PLACEHOLDER
-user_is_an_agent.heading                                    = PLACEHOLDER
-user_is_an_agent.line_1                                     = PLACEHOLDER
-user_is_an_agent.link                                       = PLACEHOLDER
+user_is_an_agent.title                                      = Nid yw asiantau wedi’u hawdurdodi i hawlio ymrestriadau
+user_is_an_agent.p1                                         = Dim ond defnyddwyr cofrestredig a’u cynorthwywyr enwebedig all wneud hyn.
 
 # Enrolment Already Allocated Error Page
 enrolment_already_allocated.title                           = Mae TAW y busnes hwn eisoes wedi cael ei hychwanegu at gyfrif treth busnes arall

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/assets/MessageLookup.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/assets/MessageLookup.scala
@@ -201,6 +201,12 @@ object MessageLookup {
 
   }
 
+  object UserIsAnAgentError {
+    val title = "Agents are not authorised to claim enrolments"
+    val p1    = "This can only be done by registered users and their nominated assistants."
+
+  }
+
   object UnmatchedUserError {
     val title   = "You cannot use this service - Claim VAT Enrolment - GOV.UK"
     val heading = "You cannot use this service"

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/JourneyControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/JourneyControllerISpec.scala
@@ -20,6 +20,8 @@ import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
+import uk.gov.hmrc.auth.core.User
 import uk.gov.hmrc.claimvatenrolmentfrontend.assets.TestConstants.{testContinueUrl, testInternalId, testJourneyId, testVatNumber}
 import uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages.{routes => errorRoutes}
 import uk.gov.hmrc.claimvatenrolmentfrontend.services.JourneyIdGenerationService
@@ -33,29 +35,46 @@ class JourneyControllerISpec extends ComponentSpecHelper with AuthStub {
     .configure(config)
     .build()
 
+  private val url = s"/journey/$testVatNumber?continueUrl=$testContinueUrl"
+
   s"GET  /journey/$testVatNumber" should {
-    "redirect to the Capture VAT Registration Date page" in {
-      stubAuth(OK, successfulAuthResponse(None, Some(testInternalId)))
+    "redirect to the Capture VAT Registration Date page" when {
+      "able to fetch their authID and they are a User credentialRole and a non-Agent affinityGroup" in {
+        stubAuth(OK, successfulAuthResponse(None, Some(testInternalId), credentialRole = Some(User.toString), affinityGroup = Individual))
 
-      lazy val result = get(s"/journey/$testVatNumber?continueUrl=$testContinueUrl")
+        lazy val result = get(url)
 
-      result.status mustBe SEE_OTHER
-
-      result.header("Location").getOrElse("None") mustBe routes.CaptureVatRegistrationDateController.show(testJourneyId).url
+        result.status mustBe SEE_OTHER
+        result.header("Location").getOrElse("None") mustBe routes.CaptureVatRegistrationDateController.show(testJourneyId).url
+      }
     }
-    "redirect to Invalid Account Error page" in {
-      stubAuth(OK, successfulAuthResponse(None, Some(testInternalId), Some("Assistant")))
 
-      lazy val result = get(s"/journey/$testVatNumber?continueUrl=$testContinueUrl")
+    "redirect to the User Is An Agent Error page" when {
+      "able to fetch their authID and they are a User credentialRole BUT they have an Agent affinityGroup" in {
+        stubAuth(OK, successfulAuthResponse(None, Some(testInternalId), credentialRole = Some(User.toString), affinityGroup = Agent))
 
-      result.status mustBe SEE_OTHER
+        lazy val result = get(url)
 
-      result.header("Location").getOrElse("None") mustBe errorRoutes.InvalidAccountTypeController.show().url
+        result.status mustBe SEE_OTHER
+        result.header("Location").getOrElse("None") mustBe errorRoutes.InvalidAccountTypeController.showUserIsAnAgentError().url
+      }
     }
+
+    "redirect to Invalid Account Error page" when {
+      "they do not have a User credentialRole" in {
+        stubAuth(OK, successfulAuthResponse(None, Some(testInternalId), Some("Assistant")))
+
+        lazy val result = get(url)
+
+        result.status mustBe SEE_OTHER
+        result.header("Location").getOrElse("None") mustBe errorRoutes.InvalidAccountTypeController.showInvalidAccountTypeError().url
+      }
+    }
+
     "return Internal Server Error" in {
       stubAuth(OK, successfulAuthResponse(None, None, None))
 
-      lazy val result = get(s"/journey/$testVatNumber?continueUrl=$testContinueUrl")
+      lazy val result = get(url)
 
       result.status mustBe INTERNAL_SERVER_ERROR
 

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/InvalidAccountTypeControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/controllers/errorPages/InvalidAccountTypeControllerISpec.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.claimvatenrolmentfrontend.controllers.errorPages
 import play.api.test.Helpers._
 import uk.gov.hmrc.claimvatenrolmentfrontend.stubs.AuthStub
 import uk.gov.hmrc.claimvatenrolmentfrontend.utils.ComponentSpecHelper
-import uk.gov.hmrc.claimvatenrolmentfrontend.views.errorPages.InvalidAccountTypeViewTests
+import uk.gov.hmrc.claimvatenrolmentfrontend.views.errorPages.{InvalidAccountTypeViewTests, UserIsAnAgentViewTests}
 
-class InvalidAccountTypeControllerISpec extends ComponentSpecHelper with InvalidAccountTypeViewTests with AuthStub {
+class InvalidAccountTypeControllerISpec extends ComponentSpecHelper with InvalidAccountTypeViewTests with UserIsAnAgentViewTests with AuthStub {
 
   s"GET /error/not-authorised" should {
     lazy val result = get("/error/not-authorised")
@@ -31,6 +31,16 @@ class InvalidAccountTypeControllerISpec extends ComponentSpecHelper with Invalid
     }
 
     testInvalidAccountTypeView(result)
+  }
+
+  s"GET /error/agent-not-authorised" should {
+    lazy val result = get("/error/agent-not-authorised")
+
+    "return OK" in {
+      result.status mustBe OK
+    }
+
+    testUserIsAnAgentErrorView(result)
   }
 
 }

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/stubs/AuthStub.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/stubs/AuthStub.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.claimvatenrolmentfrontend.stubs
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.libs.json.{JsObject, Json, Writes}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 import uk.gov.hmrc.claimvatenrolmentfrontend.assets.TestConstants.testCredentialId
 import uk.gov.hmrc.claimvatenrolmentfrontend.utils.WireMockMethods
 
@@ -25,15 +27,13 @@ trait AuthStub extends WireMockMethods {
 
   val authUrl = "/auth/authorise"
 
-  def stubAuth[T](status: Int, body: T)(implicit writes: Writes[T]): StubMapping = {
+  def stubAuth[T](status: Int, body: T)(implicit writes: Writes[T]): StubMapping =
     when(method = POST, uri = authUrl)
       .thenReturn(status = status, body = writes.writes(body))
-  }
 
-  def stubAuthFailure(): StubMapping = {
+  def stubAuthFailure(): StubMapping =
     when(method = POST, uri = authUrl)
       .thenReturn(status = 401, body = successfulAuthResponse(None))
-  }
 
   def successfulAuthResponse(internalId: Option[String]): JsObject = Json.obj(
     "internalId" -> internalId
@@ -41,13 +41,15 @@ trait AuthStub extends WireMockMethods {
 
   def successfulAuthResponse(groupId: Option[String],
                              internalId: Option[String],
-                             credentialRole: Option[String] = Some("User")): JsObject = Json.obj(
+                             credentialRole: Option[String] = Some("User"),
+                             affinityGroup: AffinityGroup = Individual): JsObject = Json.obj(
     "optionalCredentials" -> Json.obj(
-      "providerId" -> testCredentialId,
+      "providerId"   -> testCredentialId,
       "providerType" -> "GovernmentGateway"
     ),
     "groupIdentifier" -> groupId,
-    "internalId" -> internalId,
-    "credentialRole" -> credentialRole
+    "internalId"      -> internalId,
+    "credentialRole"  -> credentialRole,
+    "affinityGroup"   -> affinityGroup
   )
 }

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/UserIsAnAgentViewTests.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/UserIsAnAgentViewTests.scala
@@ -42,8 +42,5 @@ trait UserIsAnAgentViewTests extends ViewSpecHelper {
       doc.getParagraphs.get(0).text mustBe UserIsAnAgentError.p1
     }
 
-    "have a sign out button" in {
-      doc.getSubmitButton.first.text mustBe Base.signOut
-    }
   }
 }

--- a/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/UserIsAnAgentViewTests.scala
+++ b/it/test/uk/gov/hmrc/claimvatenrolmentfrontend/views/errorPages/UserIsAnAgentViewTests.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.claimvatenrolmentfrontend.views.errorPages
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.claimvatenrolmentfrontend.assets.MessageLookup.{Base, UserIsAnAgentError}
+import uk.gov.hmrc.claimvatenrolmentfrontend.utils.{ComponentSpecHelper, ViewSpecHelper}
+
+trait UserIsAnAgentViewTests extends ViewSpecHelper {
+  this: ComponentSpecHelper =>
+
+  def testUserIsAnAgentErrorView(result: => WSResponse): Unit = {
+
+    lazy val doc: Document =
+      Jsoup.parse(result.body)
+
+    "have a view with the correct title" in {
+      doc.title mustBe s"${UserIsAnAgentError.title} - Claim VAT Enrolment - GOV.UK"
+    }
+
+    "have the correct heading" in {
+      doc.getH1Elements.first.text mustBe UserIsAnAgentError.title
+    }
+
+    "have the correct text" in {
+      doc.getParagraphs.get(0).text mustBe UserIsAnAgentError.p1
+    }
+
+    "have a sign out button" in {
+      doc.getSubmitButton.first.text mustBe Base.signOut
+    }
+  }
+}


### PR DESCRIPTION
Test by signing into the GG auth wizard with any VRN number enrolment and a redirect URL:
http://localhost:9936/claim-vat-enrolment/journey/999920245?continueUrl=1234

If you sign in as an Individual or Organisation it will start the journey as normal.
If you sign in as an Agent it will redirect you to the new page.